### PR TITLE
Updated optional requirements for idefics and llava

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -10,3 +10,7 @@ timm==0.9.8
 clip @ git+https://github.com/openai/CLIP.git
 scikit-learn
 decorator
+accelerate
+transformers
+-i https://pypi.org/simple
+bitsandbytes


### PR DESCRIPTION
Fix `requirements-optional.txt` to support idefics and llava during docs creation.